### PR TITLE
fix: Fix unwrap() in ProxyError::into_response (panic in error handler)

### DIFF
--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -266,7 +266,13 @@ impl IntoResponse for ProxyError {
             .status(status)
             .header(header::CONTENT_TYPE, "application/json")
             .body(Body::from(format!(r#"{{"error":"{}"}}"#, message)))
-            .unwrap()
+            .unwrap_or_else(|_| {
+                // Fallback: minimal response that always succeeds
+                Response::builder()
+                    .status(StatusCode::INTERNAL_SERVER_ERROR)
+                    .body(Body::empty())
+                    .expect("minimal response build should never fail")
+            })
     }
 }
 
@@ -335,5 +341,67 @@ mod tests {
         assert!(!is_timeline_endpoint("/api/v1/statuses"));
         assert!(!is_timeline_endpoint("/api/v1/notifications"));
         assert!(!is_timeline_endpoint("/oauth/token"));
+    }
+
+    #[tokio::test]
+    async fn test_proxy_error_into_response_body_read() {
+        let error = ProxyError::BodyRead("test error".to_string());
+        let response = error.into_response();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(
+            response.headers().get(header::CONTENT_TYPE).unwrap(),
+            "application/json"
+        );
+
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body_str = String::from_utf8(body.to_vec()).unwrap();
+        assert!(body_str.contains("Body read error"));
+        assert!(body_str.contains("test error"));
+    }
+
+    #[tokio::test]
+    async fn test_proxy_error_into_response_upstream() {
+        let error = ProxyError::Upstream("connection refused".to_string());
+        let response = error.into_response();
+
+        assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
+
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body_str = String::from_utf8(body.to_vec()).unwrap();
+        assert!(body_str.contains("Upstream error"));
+        assert!(body_str.contains("connection refused"));
+    }
+
+    #[tokio::test]
+    async fn test_proxy_error_into_response_response_read() {
+        let error = ProxyError::ResponseRead("timeout".to_string());
+        let response = error.into_response();
+
+        assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
+
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body_str = String::from_utf8(body.to_vec()).unwrap();
+        assert!(body_str.contains("Response read error"));
+    }
+
+    #[tokio::test]
+    async fn test_proxy_error_into_response_response_build() {
+        let error = ProxyError::ResponseBuild("invalid header".to_string());
+        let response = error.into_response();
+
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body_str = String::from_utf8(body.to_vec()).unwrap();
+        assert!(body_str.contains("Response build error"));
     }
 }


### PR DESCRIPTION
## Summary

- Replaced `.unwrap()` with `.unwrap_or_else()` in `ProxyError::into_response` to prevent panics during error handling
- Added fallback that returns a minimal 500 Internal Server Error response if the primary response builder fails
- Added comprehensive tests for all `ProxyError` variants to verify error response generation

## Changes

- Replace panic-prone `.unwrap()` with safe `.unwrap_or_else()` fallback in `proxy.rs:265-275`
- Add 4 new tests for `ProxyError::into_response`:
  - `test_proxy_error_into_response_body_read`
  - `test_proxy_error_into_response_upstream`
  - `test_proxy_error_into_response_response_read`
  - `test_proxy_error_into_response_response_build`

## Testing

- All 67 tests pass (`cargo test`)
- Clippy passes with no warnings (`cargo clippy --all-features -- -D warnings`)
- Code formatting verified (`cargo fmt --check`)

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)