### PR TITLE
feat: Add transparent proxy support for web interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1009,6 +1009,7 @@ dependencies = [
  "tokio-tungstenite 0.26.2",
  "tracing",
  "tracing-subscriber",
+ "url",
  "urlencoding",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,9 @@ futures-util = "0.3"
 # URL encoding for query parameters
 urlencoding = "2"
 
+# URL parsing for redirect rewriting
+url = "2"
+
 # Serialization
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"


### PR DESCRIPTION
## Summary

Enable the proxy to work transparently with Mastodon's web interface:

- **Rewrite Location headers**: Redirect responses from upstream now point back to the proxy, enabling OAuth flows to work correctly
- **Rewrite Set-Cookie headers**: Strip Domain and Secure attributes so cookies work on the HTTP proxy origin (localhost)
- **Rewrite Origin/Referer headers**: Transform these headers to point to upstream so Rails CSRF protection validates correctly
- **Forward all headers**: Use a blacklist approach instead of whitelist, forwarding all client headers except host/connection/transfer-encoding

## Test plan

- [x] All existing tests pass
- [x] Manual testing: password reset flow works through proxy
- [x] Cookies are set correctly on localhost
- [x] CSRF validation passes for form submissions

🤖 Generated with [Claude Code](https://claude.com/claude-code)