### PR TITLE
feat: Add local development/testing infrastructure with Caddy HTTPS proxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,15 @@
 
 # Rust
 /target
+
+# SQLite databases
+*.db
+*.db-journal
+*.db-wal
+
+# Editor/IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+*~

--- a/README.md
+++ b/README.md
@@ -94,12 +94,50 @@ IvoryValley supports configuration via:
 
 ## Development
 
-```bash
-# Run tests
-cargo test
+This project uses [just](https://github.com/casey/just) as a command runner. Install with `cargo install just`.
 
+```bash
+# List all available commands
+just
+
+# Run the proxy in development mode
+just dev
+
+# Run all tests
+just test
+
+# Run all quality checks before committing
+just check
+```
+
+### Testing with Mastodon Clients
+
+Most Mastodon clients require HTTPS for OAuth. Use Caddy to add local HTTPS:
+
+```bash
+# Install Caddy
+sudo apt install caddy
+
+# Start proxy with HTTPS (available at https://localhost:8443)
+just dev-https
+```
+
+Then configure your Mastodon client to use `https://localhost:8443` as the server.
+
+**Compatible clients:**
+
+| Client | Platform | Notes |
+|--------|----------|-------|
+| Tuba | Linux (GTK) | `flatpak install flathub dev.geopjr.Tuba` |
+| Tokodon | Linux (KDE) | `apt install tokodon` |
+| Whalebird | Linux | Electron-based, AppImage available |
+| Tusky | Android | Works with HTTPS proxy |
+
+### Manual Commands
+
+```bash
 # Run with logging
-RUST_LOG=ivoryvalley=debug cargo run -- --upstream https://mastodon.social
+RUST_LOG=ivoryvalley=debug cargo run -- --upstream-url https://mastodon.social
 
 # Check code quality
 cargo clippy --all-features -- -D warnings

--- a/justfile
+++ b/justfile
@@ -1,0 +1,55 @@
+# IvoryValley development commands
+#
+# Usage: just <command>
+#
+# Run `just --list` to see all available commands.
+
+# Default upstream for development
+default_upstream := "https://mastodon.social"
+
+# List available commands
+default:
+    @just --list
+
+# Build debug binary
+build:
+    cargo build
+
+# Build release binary
+release:
+    cargo build --release
+
+# Run the proxy in development mode
+dev upstream=default_upstream:
+    cargo run -- --upstream-url {{upstream}} --host 0.0.0.0 --port 8080
+
+# Run the proxy with HTTPS via Caddy (requires: apt install caddy)
+dev-https upstream=default_upstream:
+    ./scripts/dev-https.sh {{upstream}}
+
+# Run all tests
+test:
+    cargo test
+
+# Run tests with output
+test-verbose:
+    cargo test -- --nocapture
+
+# Run clippy linter
+lint:
+    cargo clippy --all-features -- -D warnings
+
+# Format code
+fmt:
+    cargo fmt
+
+# Check formatting without modifying
+fmt-check:
+    cargo fmt --check
+
+# Run all quality checks (use before committing)
+check: test lint fmt-check
+
+# Clean build artifacts
+clean:
+    cargo clean

--- a/scripts/Caddyfile
+++ b/scripts/Caddyfile
@@ -1,0 +1,10 @@
+# Caddy configuration for local HTTPS development
+#
+# This creates a reverse proxy on https://localhost:8443 that forwards
+# to the IvoryValley proxy running on http://localhost:8080
+#
+# Caddy automatically generates and trusts a local certificate.
+
+https://localhost:8443 {
+    reverse_proxy localhost:8080
+}

--- a/scripts/dev-https.sh
+++ b/scripts/dev-https.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+#
+# Start IvoryValley with HTTPS via Caddy reverse proxy
+#
+# This script starts both the IvoryValley proxy and Caddy for local HTTPS testing.
+# Requires: caddy (apt install caddy)
+#
+# Usage: ./scripts/dev-https.sh [upstream-url]
+#
+# The proxy will be available at:
+#   - http://localhost:8080  (direct, no HTTPS)
+#   - https://localhost:8443 (via Caddy, with HTTPS)
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+UPSTREAM_URL="${1:-https://nerdculture.de}"
+
+# Check dependencies
+if ! command -v caddy &> /dev/null; then
+    echo "Error: caddy is not installed. Install with: sudo apt install caddy"
+    exit 1
+fi
+
+# Build if needed
+if [[ ! -f "$PROJECT_DIR/target/debug/ivoryvalley" ]]; then
+    echo "Building IvoryValley..."
+    cargo build --manifest-path "$PROJECT_DIR/Cargo.toml"
+fi
+
+# Cleanup function
+cleanup() {
+    echo ""
+    echo "Shutting down..."
+    kill $PROXY_PID 2>/dev/null || true
+    kill $CADDY_PID 2>/dev/null || true
+    exit 0
+}
+
+trap cleanup SIGINT SIGTERM
+
+echo "Starting IvoryValley proxy..."
+echo "  Upstream: $UPSTREAM_URL"
+echo "  HTTP:     http://localhost:8080"
+echo "  HTTPS:    https://localhost:8443"
+echo ""
+echo "Press Ctrl+C to stop"
+echo ""
+
+# Start IvoryValley
+"$PROJECT_DIR/target/debug/ivoryvalley" \
+    --upstream-url "$UPSTREAM_URL" \
+    --host 0.0.0.0 \
+    --port 8080 &
+PROXY_PID=$!
+
+# Give the proxy a moment to start
+sleep 1
+
+# Start Caddy
+caddy run --config "$SCRIPT_DIR/Caddyfile" &
+CADDY_PID=$!
+
+# Wait for either process to exit
+wait $PROXY_PID $CADDY_PID


### PR DESCRIPTION
## Summary

Add streamlined local development infrastructure so developers don't need to remember complex command lines. Most Mastodon clients require HTTPS for OAuth, so this includes Caddy reverse proxy support.

## Changes

- Add `justfile` with common commands: `just dev`, `just dev-https`, `just test`, `just check`
- Add `scripts/Caddyfile` for local HTTPS on port 8443
- Add `scripts/dev-https.sh` to start both proxy and Caddy together
- Update README with development setup instructions and compatible Mastodon clients list

## Testing

- Verified `just --list` shows all commands
- Ran `cargo test && cargo clippy --all-features -- -D warnings && cargo fmt --check` - all pass

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)