### PR TITLE
test: Add performance benchmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -145,6 +151,12 @@ name = "auto-future"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c1e7e457ea78e524f48639f551fd79703ac3f2237f5ecccdf4708f8a75ad373"
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "axum"
@@ -280,6 +292,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bd91ee7b2422bcb158d90ef4d14f75ef67f340943fc4149891dcce8f8b972a3"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -294,6 +312,33 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
 
 [[package]]
 name = "clap"
@@ -425,6 +470,69 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "futures",
+ "is-terminal",
+ "itertools",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "tokio",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -490,6 +598,12 @@ checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
 dependencies = [
  "const-random",
 ]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "encoding_rs"
@@ -571,12 +685,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -684,6 +813,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -722,6 +862,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "http"
@@ -978,10 +1124,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -997,6 +1163,7 @@ dependencies = [
  "axum-test",
  "clap",
  "config",
+ "criterion",
  "futures-util",
  "pretty_assertions",
  "reqwest",
@@ -1171,6 +1338,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1181,6 +1357,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "openssl"
@@ -1333,6 +1515,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1420,12 +1630,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -1616,6 +1858,15 @@ name = "ryu"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62049b2877bf12821e8f9ad256ee38fdc31db7387ec2d3b3f403024de2034aea"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "schannel"
@@ -1958,6 +2209,16 @@ checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -2346,6 +2607,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2435,6 +2706,15 @@ checksum = "9b32828d774c412041098d182a8b38b16ea816958e07cf40eec2bc080ae137ac"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,3 +52,10 @@ axum-test = "17"
 
 # Better test assertions
 pretty_assertions = "1"
+
+# Benchmarking
+criterion = { version = "0.5", features = ["html_reports", "async_tokio"] }
+
+[[bench]]
+name = "performance"
+harness = false

--- a/benches/performance.rs
+++ b/benches/performance.rs
@@ -1,0 +1,391 @@
+//! Performance benchmarks for IvoryValley proxy.
+//!
+//! Run with: cargo bench
+//! View HTML reports in: target/criterion/
+
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use ivoryvalley::db::{extract_dedup_uri, SeenUriStore};
+use serde_json::{json, Value};
+use std::time::Duration;
+
+/// Generate a mock status with a unique URI.
+fn generate_status(id: u64) -> Value {
+    json!({
+        "id": id.to_string(),
+        "uri": format!("https://mastodon.social/users/testuser/statuses/{}", id),
+        "content": "<p>Test content for status</p>",
+        "created_at": "2024-01-01T12:00:00.000Z",
+        "account": {
+            "id": "1",
+            "username": "testuser",
+            "acct": "testuser",
+            "display_name": "Test User"
+        },
+        "reblog": null,
+        "replies_count": 0,
+        "reblogs_count": 0,
+        "favourites_count": 0
+    })
+}
+
+/// Generate a mock reblog status.
+fn generate_reblog(id: u64, original_id: u64) -> Value {
+    json!({
+        "id": id.to_string(),
+        "uri": format!("https://mastodon.social/users/booster/statuses/{}", id),
+        "content": "",
+        "created_at": "2024-01-01T12:00:00.000Z",
+        "account": {
+            "id": "2",
+            "username": "booster",
+            "acct": "booster",
+            "display_name": "Booster"
+        },
+        "reblog": {
+            "id": original_id.to_string(),
+            "uri": format!("https://fosstodon.org/users/original/statuses/{}", original_id),
+            "content": "<p>Original content</p>",
+            "account": {
+                "id": "3",
+                "username": "original",
+                "acct": "original@fosstodon.org"
+            }
+        },
+        "replies_count": 0,
+        "reblogs_count": 0,
+        "favourites_count": 0
+    })
+}
+
+/// Benchmark database check_and_mark operations.
+fn bench_db_check_and_mark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("db_check_and_mark");
+
+    // Benchmark single check_and_mark on empty database
+    group.bench_function("empty_db", |b| {
+        let store = SeenUriStore::open(":memory:").unwrap();
+        let mut counter = 0u64;
+        b.iter(|| {
+            counter += 1;
+            let uri = format!("https://example.com/status/{}", counter);
+            black_box(store.check_and_mark(&uri).unwrap())
+        });
+    });
+
+    // Benchmark check_and_mark with existing URIs (hit rate test)
+    group.bench_function("existing_uri", |b| {
+        let store = SeenUriStore::open(":memory:").unwrap();
+        let uri = "https://example.com/status/1";
+        store.mark_seen(uri).unwrap();
+        b.iter(|| black_box(store.check_and_mark(uri).unwrap()));
+    });
+
+    group.finish();
+}
+
+/// Benchmark database with varying sizes.
+fn bench_db_scaling(c: &mut Criterion) {
+    let mut group = c.benchmark_group("db_scaling");
+    group.measurement_time(Duration::from_secs(10));
+
+    for size in [1_000, 10_000, 100_000].iter() {
+        group.bench_with_input(BenchmarkId::new("is_seen", size), size, |b, &size| {
+            let store = SeenUriStore::open(":memory:").unwrap();
+
+            // Pre-populate the database
+            for i in 0..size {
+                let uri = format!("https://example.com/status/{}", i);
+                store.mark_seen(&uri).unwrap();
+            }
+
+            // Benchmark lookup in the middle of the dataset
+            let test_uri = format!("https://example.com/status/{}", size / 2);
+            b.iter(|| black_box(store.is_seen(&test_uri).unwrap()));
+        });
+
+        group.bench_with_input(
+            BenchmarkId::new("check_and_mark_new", size),
+            size,
+            |b, &size| {
+                let store = SeenUriStore::open(":memory:").unwrap();
+
+                // Pre-populate the database
+                for i in 0..size {
+                    let uri = format!("https://example.com/status/{}", i);
+                    store.mark_seen(&uri).unwrap();
+                }
+
+                // Benchmark inserting new URIs
+                let mut counter = size;
+                b.iter(|| {
+                    counter += 1;
+                    let uri = format!("https://example.com/status/{}", counter);
+                    black_box(store.check_and_mark(&uri).unwrap())
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+/// Benchmark extract_dedup_uri function.
+fn bench_extract_uri(c: &mut Criterion) {
+    let mut group = c.benchmark_group("extract_uri");
+
+    let regular_status = generate_status(1);
+    let reblog_status = generate_reblog(2, 1);
+
+    group.bench_function("regular_status", |b| {
+        b.iter(|| black_box(extract_dedup_uri(&regular_status)));
+    });
+
+    group.bench_function("reblog_status", |b| {
+        b.iter(|| black_box(extract_dedup_uri(&reblog_status)));
+    });
+
+    group.finish();
+}
+
+/// Benchmark timeline filtering with various feed sizes.
+fn bench_timeline_filtering(c: &mut Criterion) {
+    let mut group = c.benchmark_group("timeline_filtering");
+    group.measurement_time(Duration::from_secs(10));
+
+    for size in [20, 100, 500].iter() {
+        group.throughput(Throughput::Elements(*size as u64));
+
+        group.bench_with_input(BenchmarkId::new("all_new", size), size, |b, &size| {
+            b.iter_batched(
+                || {
+                    let store = SeenUriStore::open(":memory:").unwrap();
+                    let statuses: Vec<Value> =
+                        (0..size).map(|i| generate_status(i as u64)).collect();
+                    (store, statuses)
+                },
+                |(store, statuses)| {
+                    for status in &statuses {
+                        if let Some(uri) = extract_dedup_uri(status) {
+                            black_box(store.check_and_mark(uri).unwrap());
+                        }
+                    }
+                },
+                criterion::BatchSize::SmallInput,
+            );
+        });
+
+        group.bench_with_input(BenchmarkId::new("all_seen", size), size, |b, &size| {
+            b.iter_batched(
+                || {
+                    let store = SeenUriStore::open(":memory:").unwrap();
+                    let statuses: Vec<Value> =
+                        (0..size).map(|i| generate_status(i as u64)).collect();
+                    // Pre-mark all as seen
+                    for status in &statuses {
+                        if let Some(uri) = extract_dedup_uri(status) {
+                            store.mark_seen(uri).unwrap();
+                        }
+                    }
+                    (store, statuses)
+                },
+                |(store, statuses)| {
+                    for status in &statuses {
+                        if let Some(uri) = extract_dedup_uri(status) {
+                            black_box(store.check_and_mark(uri).unwrap());
+                        }
+                    }
+                },
+                criterion::BatchSize::SmallInput,
+            );
+        });
+
+        // Mixed: 50% new, 50% seen
+        group.bench_with_input(BenchmarkId::new("mixed_50_50", size), size, |b, &size| {
+            b.iter_batched(
+                || {
+                    let store = SeenUriStore::open(":memory:").unwrap();
+                    let statuses: Vec<Value> =
+                        (0..size).map(|i| generate_status(i as u64)).collect();
+                    // Mark first half as seen
+                    for status in statuses.iter().take(size / 2) {
+                        if let Some(uri) = extract_dedup_uri(status) {
+                            store.mark_seen(uri).unwrap();
+                        }
+                    }
+                    (store, statuses)
+                },
+                |(store, statuses)| {
+                    for status in &statuses {
+                        if let Some(uri) = extract_dedup_uri(status) {
+                            black_box(store.check_and_mark(uri).unwrap());
+                        }
+                    }
+                },
+                criterion::BatchSize::SmallInput,
+            );
+        });
+    }
+
+    group.finish();
+}
+
+/// Benchmark JSON parsing and serialization (important for timeline processing).
+fn bench_json_processing(c: &mut Criterion) {
+    let mut group = c.benchmark_group("json_processing");
+
+    for size in [20, 100, 500].iter() {
+        let statuses: Vec<Value> = (0..*size).map(|i| generate_status(i as u64)).collect();
+        let json_bytes = serde_json::to_vec(&statuses).unwrap();
+
+        group.throughput(Throughput::Bytes(json_bytes.len() as u64));
+
+        group.bench_with_input(BenchmarkId::new("parse", size), &json_bytes, |b, bytes| {
+            b.iter(|| {
+                let parsed: Vec<Value> = serde_json::from_slice(bytes).unwrap();
+                black_box(parsed)
+            });
+        });
+
+        group.bench_with_input(
+            BenchmarkId::new("serialize", size),
+            &statuses,
+            |b, statuses| {
+                b.iter(|| {
+                    let bytes = serde_json::to_vec(statuses).unwrap();
+                    black_box(bytes)
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+/// Benchmark full pipeline: parse, filter, serialize.
+fn bench_full_pipeline(c: &mut Criterion) {
+    let mut group = c.benchmark_group("full_pipeline");
+    group.measurement_time(Duration::from_secs(15));
+
+    for size in [20, 100, 500].iter() {
+        let statuses: Vec<Value> = (0..*size).map(|i| generate_status(i as u64)).collect();
+        let json_bytes = serde_json::to_vec(&statuses).unwrap();
+
+        group.throughput(Throughput::Elements(*size as u64));
+
+        // Full pipeline with fresh database (all new)
+        group.bench_with_input(
+            BenchmarkId::new("all_new", size),
+            &json_bytes,
+            |b, bytes| {
+                b.iter_batched(
+                    || SeenUriStore::open(":memory:").unwrap(),
+                    |store| {
+                        // Parse
+                        let statuses: Vec<Value> = serde_json::from_slice(bytes).unwrap();
+
+                        // Filter
+                        let filtered: Vec<Value> = statuses
+                            .into_iter()
+                            .filter(|status| {
+                                if let Some(uri) = extract_dedup_uri(status) {
+                                    !store.check_and_mark(uri).unwrap()
+                                } else {
+                                    true
+                                }
+                            })
+                            .collect();
+
+                        // Serialize
+                        let result = serde_json::to_vec(&filtered).unwrap();
+                        black_box(result)
+                    },
+                    criterion::BatchSize::SmallInput,
+                );
+            },
+        );
+
+        // Full pipeline with pre-populated database (50% duplicates)
+        group.bench_with_input(
+            BenchmarkId::new("half_duplicates", size),
+            &json_bytes,
+            |b, bytes| {
+                b.iter_batched(
+                    || {
+                        let store = SeenUriStore::open(":memory:").unwrap();
+                        // Pre-mark half as seen
+                        for i in 0..(*size / 2) {
+                            let uri =
+                                format!("https://mastodon.social/users/testuser/statuses/{}", i);
+                            store.mark_seen(&uri).unwrap();
+                        }
+                        store
+                    },
+                    |store| {
+                        // Parse
+                        let statuses: Vec<Value> = serde_json::from_slice(bytes).unwrap();
+
+                        // Filter
+                        let filtered: Vec<Value> = statuses
+                            .into_iter()
+                            .filter(|status| {
+                                if let Some(uri) = extract_dedup_uri(status) {
+                                    !store.check_and_mark(uri).unwrap()
+                                } else {
+                                    true
+                                }
+                            })
+                            .collect();
+
+                        // Serialize
+                        let result = serde_json::to_vec(&filtered).unwrap();
+                        black_box(result)
+                    },
+                    criterion::BatchSize::SmallInput,
+                );
+            },
+        );
+    }
+
+    group.finish();
+}
+
+/// Benchmark cleanup operation with varying database sizes.
+fn bench_cleanup(c: &mut Criterion) {
+    let mut group = c.benchmark_group("cleanup");
+    group.measurement_time(Duration::from_secs(10));
+
+    for size in [1_000, 10_000, 50_000].iter() {
+        group.bench_with_input(BenchmarkId::new("full_cleanup", size), size, |b, &size| {
+            b.iter_batched(
+                || {
+                    let store = SeenUriStore::open(":memory:").unwrap();
+                    for i in 0..size {
+                        let uri = format!("https://example.com/status/{}", i);
+                        store.mark_seen(&uri).unwrap();
+                    }
+                    store
+                },
+                |store| {
+                    // Remove all entries
+                    black_box(store.cleanup(0).unwrap())
+                },
+                criterion::BatchSize::LargeInput,
+            );
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_db_check_and_mark,
+    bench_db_scaling,
+    bench_extract_uri,
+    bench_timeline_filtering,
+    bench_json_processing,
+    bench_full_pipeline,
+    bench_cleanup,
+);
+
+criterion_main!(benches);


### PR DESCRIPTION
## Summary

- Add criterion-based performance benchmarks for IvoryValley proxy
- Measure database operations, timeline filtering, and full pipeline throughput
- Establish baseline metrics for future optimization work

## Changes

- Add `criterion` with `async_tokio` feature to dev-dependencies
- Create comprehensive benchmark suite in `benches/performance.rs`
- Benchmarks cover:
  - `db_check_and_mark`: Atomic check-and-mark operations on empty and populated DBs
  - `db_scaling`: Performance with 1K, 10K, 100K stored URIs  
  - `extract_uri`: URI extraction from regular and reblog statuses
  - `timeline_filtering`: Deduplication with all-new, all-seen, and mixed scenarios
  - `json_processing`: Parse/serialize throughput for various feed sizes
  - `full_pipeline`: Complete parse → filter → serialize pipeline
  - `cleanup`: Database cleanup operation performance

## Benchmark Results

| Benchmark | Result |
|-----------|--------|
| `check_and_mark` (empty DB) | ~3.8 µs |
| `check_and_mark` (existing URI) | ~1.6 µs |
| Full pipeline (20 statuses) | ~118 µs |
| Full pipeline (100 statuses) | ~576 µs |
| Full pipeline (500 statuses) | ~3.0 ms |
| Throughput | ~165-195K elem/s |

## Testing

```bash
# Run all benchmarks
cargo bench

# Run specific benchmark group
cargo bench -- db_check_and_mark
cargo bench -- full_pipeline
```

HTML reports generated in `target/criterion/`

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)