### PR TITLE
feat: Create Docker packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ env:
 
 permissions:
   contents: write
+  packages: write
 
 jobs:
   # Build binaries for each platform
@@ -123,3 +124,52 @@ jobs:
 
       - name: Publish to crates.io
         run: cargo publish --token ${{ steps.crates-io-auth.outputs.token }}
+
+  # Build and push Docker image to GitHub Container Registry
+  docker:
+    name: Build Docker image
+    needs: publish-crates
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Get version from tag
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ steps.version.outputs.version }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+# Build stage - install from crates.io
+FROM rust:1-slim-bookworm AS builder
+
+# Install ivoryvalley from crates.io
+# The version is passed as a build argument
+ARG VERSION
+RUN cargo install ivoryvalley --version ${VERSION}
+
+# Runtime stage - minimal image
+FROM debian:bookworm-slim
+
+# Install ca-certificates for HTTPS connections and create non-root user
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
+    && useradd -r -u 1000 -m ivoryvalley
+
+# Copy the binary from builder
+COPY --from=builder /usr/local/cargo/bin/ivoryvalley /usr/local/bin/ivoryvalley
+
+# Create data directory for SQLite database
+RUN mkdir -p /data && chown ivoryvalley:ivoryvalley /data
+
+# Switch to non-root user
+USER ivoryvalley
+WORKDIR /data
+
+# Default environment variables
+ENV IVORYVALLEY_HOST=0.0.0.0 \
+    IVORYVALLEY_PORT=8080 \
+    IVORYVALLEY_DATABASE_PATH=/data/ivoryvalley.db
+
+# Expose the proxy port
+EXPOSE 8080
+
+# Run the proxy
+ENTRYPOINT ["ivoryvalley"]

--- a/README.md
+++ b/README.md
@@ -39,10 +39,41 @@ IvoryValley sits between your Mastodon client and the upstream server, filtering
 
 ## Installation
 
+### From Docker (Recommended)
+
+Pull and run the latest image:
+
+```bash
+docker pull ghcr.io/jensens/ivoryvalley:latest
+docker run -d \
+  --name ivoryvalley \
+  -p 8080:8080 \
+  -v ivoryvalley-data:/data \
+  -e IVORYVALLEY_UPSTREAM_URL=https://mastodon.social \
+  ghcr.io/jensens/ivoryvalley:latest
+```
+
+Or use docker-compose (see [docker-compose.yml](docker-compose.yml)):
+
+```bash
+# Edit docker-compose.yml with your upstream URL
+docker compose up -d
+```
+
+### From crates.io
+
+```bash
+cargo install ivoryvalley
+```
+
+### From GitHub Releases
+
+Download the appropriate binary for your platform from the [Releases](https://github.com/jensens/ivoryvalley/releases) page.
+
 ### From Source
 
 ```bash
-git clone https://github.com/your-username/ivoryvalley.git
+git clone https://github.com/jensens/ivoryvalley.git
 cd ivoryvalley
 cargo build --release
 ```

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -81,6 +81,10 @@ Once the release is published, GitHub Actions automatically:
 
 3. **Publishes to crates.io** after all builds complete
 
+4. **Builds and pushes Docker image** to GitHub Container Registry (ghcr.io)
+   - Multi-platform: `linux/amd64` and `linux/arm64`
+   - Tags: version (e.g., `0.1.0`), major.minor (e.g., `0.1`), major (e.g., `0`), and `latest`
+
 ## Release Artifacts
 
 After the workflow completes, the release will contain:
@@ -92,6 +96,7 @@ After the workflow completes, the release will contain:
 | macOS x86_64 | `ivoryvalley-X.Y.Z-x86_64-apple-darwin.tar.gz` |
 | macOS ARM64 | `ivoryvalley-X.Y.Z-aarch64-apple-darwin.tar.gz` |
 | Windows x86_64 | `ivoryvalley-X.Y.Z-x86_64-pc-windows-msvc.zip` |
+| Docker (amd64, arm64) | `ghcr.io/jensens/ivoryvalley:X.Y.Z` |
 
 ## Version Numbering
 
@@ -127,6 +132,12 @@ Common issues:
 - Verify the workflow has `id-token: write` permission
 - If environment protection rules are enabled, ensure the deployment was approved
 
+### Docker Build Failure
+
+- Verify the crates.io publish succeeded first (Docker depends on it)
+- Check that the version tag exists on crates.io
+- ARM64 builds use QEMU emulation and may take longer
+
 ### Manual Publishing
 
 If automated publishing fails, you can publish manually:
@@ -136,35 +147,3 @@ cargo publish
 ```
 
 Note: This requires you to be logged in via `cargo login`.
-
-## Installation from Release
-
-Users can install from various sources:
-
-### From crates.io
-
-```bash
-cargo install ivoryvalley
-```
-
-### From GitHub Releases
-
-Download the appropriate archive for your platform and extract:
-
-```bash
-# Linux/macOS
-tar xzf ivoryvalley-X.Y.Z-<target>.tar.gz
-./ivoryvalley --help
-
-# Windows
-unzip ivoryvalley-X.Y.Z-x86_64-pc-windows-msvc.zip
-ivoryvalley.exe --help
-```
-
-### From Source
-
-```bash
-git clone https://github.com/jensens/ivoryvalley.git
-cd ivoryvalley
-cargo build --release
-```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+services:
+  ivoryvalley:
+    image: ghcr.io/jensens/ivoryvalley:latest
+    container_name: ivoryvalley
+    restart: unless-stopped
+    ports:
+      - "8080:8080"
+    volumes:
+      # Persist SQLite database
+      - ivoryvalley-data:/data
+    environment:
+      # Required: Upstream Mastodon server URL
+      IVORYVALLEY_UPSTREAM_URL: https://mastodon.social
+      # Optional: Adjust these as needed
+      # IVORYVALLEY_PORT: 8080
+      # IVORYVALLEY_MAX_BODY_SIZE: 52428800
+      # IVORYVALLEY_CONNECT_TIMEOUT_SECS: 10
+      # IVORYVALLEY_REQUEST_TIMEOUT_SECS: 30
+
+volumes:
+  ivoryvalley-data:


### PR DESCRIPTION
## Summary

- Add Dockerfile using crates.io release for minimal runtime image
- Add docker-compose.yml for easy deployment with volume persistence
- Add GitHub Action job to build and push to ghcr.io after crates.io publish
- Multi-platform support: linux/amd64 and linux/arm64
- Update README.md with Docker installation instructions
- Update RELEASE.md with Docker build information

## Changes

- **Dockerfile**: Multi-stage build that installs from crates.io, uses minimal debian:bookworm-slim runtime, runs as non-root user
- **docker-compose.yml**: Ready-to-use compose file with environment variable configuration and named volume for SQLite persistence
- **.github/workflows/release.yml**: Added `docker` job that runs after `publish-crates`, builds multi-arch images, and pushes to ghcr.io with version tags
- **README.md**: Added installation instructions for Docker, crates.io, and GitHub releases
- **RELEASE.md**: Added Docker build section and artifact info

## Testing

- All existing tests pass (`cargo test`)
- No clippy warnings (`cargo clippy --all-features -- -D warnings`)
- Code properly formatted (`cargo fmt --check`)

Note: Docker image build will work after first crates.io publish as it depends on the published version.

Closes #22