### PR TITLE
fix: Change env var prefix from IVORYVALLEY_ to IV_

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1109,7 +1109,7 @@ checksum = "7ee5b5339afb4c41626dde77b7a611bd4f2c202b897852b4bcf5d03eddc61010"
 
 [[package]]
 name = "ivoryvalley"
-version = "0.2.0"
+version = "0.2.2"
 dependencies = [
  "axum",
  "axum-test",


### PR DESCRIPTION
## Summary

Changes the environment variable prefix from `IVORYVALLEY_` to `IV_` to avoid collision with Kubernetes service discovery environment variables. When deploying a service named "ivoryvalley" in Kubernetes, it automatically injects variables like `IVORYVALLEY_PORT=tcp://10.43.62.146:80` which were colliding with the config env vars and causing parse errors.

## Changes

- Updated all `CliArgs` env attributes to use `IV_` prefix (e.g., `IV_PORT`, `IV_HOST`, `IV_UPSTREAM_URL`)
- Removed redundant `Environment` source from config crate (clap's `env` attribute already handles env var reading)
- Added tests verifying the new prefix works and Kubernetes-style vars are ignored
- Added documentation in config.rs explaining why `IV_` prefix is used

## Testing

- Added `test_env_var_prefix_uses_iv` - verifies `IV_*` env vars are read correctly
- Added `test_kubernetes_style_env_vars_ignored` - verifies `IVORYVALLEY_*` vars don't cause errors
- All existing tests pass
- Ran `cargo clippy --all-features -- -D warnings` with no errors
- Ran `cargo fmt --check` with no issues

Closes #74