### PR TITLE
feat: Add graceful shutdown handling

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod config;
 pub mod db;
 pub mod proxy;
 pub mod recording;
+pub mod shutdown;
 pub mod websocket;
 
 // Re-export main deduplication API

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 use ivoryvalley::config::Config;
 use ivoryvalley::db::SeenUriStore;
 use ivoryvalley::proxy::create_proxy_router;
+use ivoryvalley::shutdown::shutdown_signal;
 use tokio::net::TcpListener;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
@@ -37,5 +38,10 @@ async fn main() {
 
     tracing::info!("Proxy server running on http://{}", config.bind_addr());
 
-    axum::serve(listener, app).await.expect("Server error");
+    axum::serve(listener, app)
+        .with_graceful_shutdown(shutdown_signal())
+        .await
+        .expect("Server error");
+
+    tracing::info!("Server shutdown complete");
 }

--- a/src/shutdown.rs
+++ b/src/shutdown.rs
@@ -1,0 +1,74 @@
+//! Graceful shutdown handling for the IvoryValley proxy server.
+//!
+//! This module provides signal handling for graceful shutdown on SIGTERM and SIGINT.
+//! When a shutdown signal is received, in-flight requests are allowed to complete
+//! before the server terminates.
+
+use tokio::signal;
+
+/// Creates a future that completes when a shutdown signal is received.
+///
+/// This function listens for:
+/// - SIGINT (Ctrl+C)
+/// - SIGTERM (common in containerized environments)
+///
+/// When either signal is received, the future completes, allowing the server
+/// to initiate graceful shutdown.
+///
+/// # Example
+///
+/// ```ignore
+/// use ivoryvalley::shutdown::shutdown_signal;
+///
+/// axum::serve(listener, app)
+///     .with_graceful_shutdown(shutdown_signal())
+///     .await
+///     .expect("Server error");
+/// ```
+pub async fn shutdown_signal() {
+    let ctrl_c = async {
+        signal::ctrl_c()
+            .await
+            .expect("Failed to install Ctrl+C handler");
+    };
+
+    #[cfg(unix)]
+    let terminate = async {
+        signal::unix::signal(signal::unix::SignalKind::terminate())
+            .expect("Failed to install SIGTERM handler")
+            .recv()
+            .await;
+    };
+
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+
+    tokio::select! {
+        () = ctrl_c => {
+            tracing::info!("Received SIGINT, initiating graceful shutdown");
+        }
+        () = terminate => {
+            tracing::info!("Received SIGTERM, initiating graceful shutdown");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+    use tokio::time::timeout;
+
+    /// Test that shutdown_signal returns a valid future that can be polled.
+    /// We can't easily trigger actual signals in tests, but we can verify
+    /// the future doesn't immediately complete (it waits for a signal).
+    #[tokio::test]
+    async fn test_shutdown_signal_waits_for_signal() {
+        // The shutdown signal should not complete within a short timeout
+        // since no signal has been sent
+        let result = timeout(Duration::from_millis(10), shutdown_signal()).await;
+
+        // Should timeout (Err) because no signal was sent
+        assert!(result.is_err(), "shutdown_signal should wait for a signal");
+    }
+}


### PR DESCRIPTION
## Summary

Add signal handling for graceful shutdown of the IvoryValley proxy server. When SIGTERM or SIGINT is received, in-flight requests are allowed to complete before the server terminates.

## Changes

- Create `src/shutdown.rs` module with `shutdown_signal()` function
- Handle both SIGINT (Ctrl+C) and SIGTERM (containerized environments)
- Use `tokio::select!` for cross-platform signal handling (Unix-specific SIGTERM, universal Ctrl+C)
- Log shutdown events for observability
- Update `main.rs` to use `with_graceful_shutdown()`

## Testing

- Unit test verifies `shutdown_signal()` properly waits for signals (doesn't immediately complete)
- All existing tests pass
- Clippy and fmt checks pass

Closes #52