### PR TITLE
feat: Implement background cleanup task for old URIs

### DIFF
--- a/src/cleanup.rs
+++ b/src/cleanup.rs
@@ -1,0 +1,108 @@
+//! Background cleanup task for old URIs.
+//!
+//! This module provides a background task that periodically cleans up
+//! old entries from the SeenUriStore to prevent unbounded database growth.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use crate::db::SeenUriStore;
+
+/// Spawns a background task that periodically cleans up old URIs.
+///
+/// The task runs at the specified interval and removes entries older than
+/// `max_age_secs` from the store. Cleanup results are logged.
+///
+/// # Arguments
+///
+/// * `store` - The SeenUriStore to clean up
+/// * `interval_secs` - Seconds between cleanup runs
+/// * `max_age_secs` - Maximum age in seconds for entries (older entries are removed)
+///
+/// # Returns
+///
+/// A `JoinHandle` for the spawned task, which can be used to abort the task
+/// or wait for it to complete (though normally it runs indefinitely).
+pub fn spawn_cleanup_task(
+    store: Arc<SeenUriStore>,
+    interval_secs: u64,
+    max_age_secs: u64,
+) -> tokio::task::JoinHandle<()> {
+    tracing::info!(
+        "Starting cleanup task: interval={}s, max_age={}s ({}d)",
+        interval_secs,
+        max_age_secs,
+        max_age_secs / 86400
+    );
+
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(Duration::from_secs(interval_secs));
+
+        // Skip the first tick which fires immediately
+        interval.tick().await;
+
+        loop {
+            interval.tick().await;
+
+            match store.cleanup(max_age_secs) {
+                Ok(removed) => {
+                    if removed > 0 {
+                        tracing::info!("Cleaned up {} old URIs", removed);
+                    } else {
+                        tracing::debug!("Cleanup: no old URIs to remove");
+                    }
+                }
+                Err(e) => {
+                    tracing::error!("Cleanup failed: {}", e);
+                }
+            }
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[tokio::test]
+    async fn test_cleanup_logic() {
+        // Test the cleanup logic directly without spawning a task
+        let store = Arc::new(SeenUriStore::open(":memory:").unwrap());
+
+        // Add some URIs
+        store.mark_seen("https://example.com/1").unwrap();
+        store.mark_seen("https://example.com/2").unwrap();
+
+        assert!(store.is_seen("https://example.com/1").unwrap());
+        assert!(store.is_seen("https://example.com/2").unwrap());
+
+        // Cleanup with max_age=0 removes all
+        let removed = store.cleanup(0).unwrap();
+        assert_eq!(removed, 2);
+
+        // URIs should be cleaned up
+        assert!(!store.is_seen("https://example.com/1").unwrap());
+        assert!(!store.is_seen("https://example.com/2").unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_cleanup_task_preserves_recent_entries() {
+        let store = Arc::new(SeenUriStore::open(":memory:").unwrap());
+
+        // Add a URI
+        store.mark_seen("https://example.com/recent").unwrap();
+
+        // Spawn cleanup task with 1 second interval but large max_age
+        let handle = spawn_cleanup_task(store.clone(), 1, 999999);
+
+        // Wait a bit (task waits for first interval before running)
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        // URI should still be there (cleanup hasn't run yet, and when it does,
+        // the entry is recent so it won't be removed)
+        assert!(store.is_seen("https://example.com/recent").unwrap());
+
+        handle.abort();
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 //! IvoryValley - Mastodon proxy for content deduplication
 
+pub mod cleanup;
 pub mod config;
 pub mod db;
 pub mod proxy;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,6 @@
+use std::sync::Arc;
+
+use ivoryvalley::cleanup::spawn_cleanup_task;
 use ivoryvalley::config::Config;
 use ivoryvalley::db::SeenUriStore;
 use ivoryvalley::proxy::create_proxy_router;
@@ -26,6 +29,14 @@ async fn main() {
     // Open the seen URI store for deduplication
     let seen_store =
         SeenUriStore::open(&config.database_path).expect("Failed to open seen URI store");
+    let seen_store = Arc::new(seen_store);
+
+    // Start the background cleanup task
+    let _cleanup_handle = spawn_cleanup_task(
+        seen_store.clone(),
+        config.cleanup_interval_secs,
+        config.cleanup_max_age_secs,
+    );
 
     // Create the router
     let app = create_proxy_router(config.clone(), seen_store);

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -175,9 +175,9 @@ fn is_timeline_endpoint(path: &str) -> bool {
 }
 
 /// Create the proxy router with all routes
-pub fn create_proxy_router(config: Config, seen_store: SeenUriStore) -> Router {
-    // Wrap the store in Arc to share between HTTP proxy and WebSocket handlers
-    let seen_store = Arc::new(seen_store);
+pub fn create_proxy_router(config: Config, seen_store: Arc<SeenUriStore>) -> Router {
+    // The store is already wrapped in Arc for sharing between HTTP proxy,
+    // WebSocket handlers, and the background cleanup task
 
     let app_state = AppState::new(config, seen_store.clone());
     let ws_state = WebSocketState::new(app_state.clone(), seen_store);

--- a/tests/client_session_test.rs
+++ b/tests/client_session_test.rs
@@ -651,7 +651,7 @@ async fn test_app_launch_sequence() {
     let db_path = temp_dir.path().join("test.db");
     let config = Config::new(&upstream.url(), "0.0.0.0", 0, db_path);
     let seen_store = SeenUriStore::open(":memory:").unwrap();
-    let app = create_proxy_router(config, seen_store);
+    let app = create_proxy_router(config, std::sync::Arc::new(seen_store));
 
     let client = axum_test::TestServer::new(app).unwrap();
 
@@ -703,7 +703,7 @@ async fn test_timeline_refresh_with_min_id() {
     let db_path = temp_dir.path().join("test.db");
     let config = Config::new(&upstream.url(), "0.0.0.0", 0, db_path);
     let seen_store = SeenUriStore::open(":memory:").unwrap();
-    let app = create_proxy_router(config, seen_store);
+    let app = create_proxy_router(config, std::sync::Arc::new(seen_store));
 
     let client = axum_test::TestServer::new(app).unwrap();
 
@@ -745,7 +745,7 @@ async fn test_timeline_load_more_with_max_id() {
     let db_path = temp_dir.path().join("test.db");
     let config = Config::new(&upstream.url(), "0.0.0.0", 0, db_path);
     let seen_store = SeenUriStore::open(":memory:").unwrap();
-    let app = create_proxy_router(config, seen_store);
+    let app = create_proxy_router(config, std::sync::Arc::new(seen_store));
 
     let client = axum_test::TestServer::new(app).unwrap();
 
@@ -787,7 +787,7 @@ async fn test_timeline_gap_fill_with_since_id() {
     let db_path = temp_dir.path().join("test.db");
     let config = Config::new(&upstream.url(), "0.0.0.0", 0, db_path);
     let seen_store = SeenUriStore::open(":memory:").unwrap();
-    let app = create_proxy_router(config, seen_store);
+    let app = create_proxy_router(config, std::sync::Arc::new(seen_store));
 
     let client = axum_test::TestServer::new(app).unwrap();
 
@@ -815,7 +815,7 @@ async fn test_timeline_link_header_preserved() {
     let db_path = temp_dir.path().join("test.db");
     let config = Config::new(&upstream.url(), "0.0.0.0", 0, db_path);
     let seen_store = SeenUriStore::open(":memory:").unwrap();
-    let app = create_proxy_router(config, seen_store);
+    let app = create_proxy_router(config, std::sync::Arc::new(seen_store));
 
     let client = axum_test::TestServer::new(app).unwrap();
 
@@ -845,7 +845,7 @@ async fn test_post_status() {
     let db_path = temp_dir.path().join("test.db");
     let config = Config::new(&upstream.url(), "0.0.0.0", 0, db_path);
     let seen_store = SeenUriStore::open(":memory:").unwrap();
-    let app = create_proxy_router(config, seen_store);
+    let app = create_proxy_router(config, std::sync::Arc::new(seen_store));
 
     let client = axum_test::TestServer::new(app).unwrap();
 
@@ -873,7 +873,7 @@ async fn test_favourite_status() {
     let db_path = temp_dir.path().join("test.db");
     let config = Config::new(&upstream.url(), "0.0.0.0", 0, db_path);
     let seen_store = SeenUriStore::open(":memory:").unwrap();
-    let app = create_proxy_router(config, seen_store);
+    let app = create_proxy_router(config, std::sync::Arc::new(seen_store));
 
     let client = axum_test::TestServer::new(app).unwrap();
 
@@ -895,7 +895,7 @@ async fn test_reblog_status() {
     let db_path = temp_dir.path().join("test.db");
     let config = Config::new(&upstream.url(), "0.0.0.0", 0, db_path);
     let seen_store = SeenUriStore::open(":memory:").unwrap();
-    let app = create_proxy_router(config, seen_store);
+    let app = create_proxy_router(config, std::sync::Arc::new(seen_store));
 
     let client = axum_test::TestServer::new(app).unwrap();
 
@@ -918,7 +918,7 @@ async fn test_view_thread_context() {
     let db_path = temp_dir.path().join("test.db");
     let config = Config::new(&upstream.url(), "0.0.0.0", 0, db_path);
     let seen_store = SeenUriStore::open(":memory:").unwrap();
-    let app = create_proxy_router(config, seen_store);
+    let app = create_proxy_router(config, std::sync::Arc::new(seen_store));
 
     let client = axum_test::TestServer::new(app).unwrap();
 
@@ -946,7 +946,7 @@ async fn test_deduplication_across_timeline_fetches() {
     let db_path = temp_dir.path().join("test.db");
     let config = Config::new(&upstream.url(), "0.0.0.0", 0, db_path);
     let seen_store = SeenUriStore::open(":memory:").unwrap();
-    let app = create_proxy_router(config, seen_store);
+    let app = create_proxy_router(config, std::sync::Arc::new(seen_store));
 
     let client = axum_test::TestServer::new(app).unwrap();
 
@@ -983,7 +983,7 @@ async fn test_public_timeline() {
     let db_path = temp_dir.path().join("test.db");
     let config = Config::new(&upstream.url(), "0.0.0.0", 0, db_path);
     let seen_store = SeenUriStore::open(":memory:").unwrap();
-    let app = create_proxy_router(config, seen_store);
+    let app = create_proxy_router(config, std::sync::Arc::new(seen_store));
 
     let client = axum_test::TestServer::new(app).unwrap();
 
@@ -1002,7 +1002,7 @@ async fn test_hashtag_timeline() {
     let db_path = temp_dir.path().join("test.db");
     let config = Config::new(&upstream.url(), "0.0.0.0", 0, db_path);
     let seen_store = SeenUriStore::open(":memory:").unwrap();
-    let app = create_proxy_router(config, seen_store);
+    let app = create_proxy_router(config, std::sync::Arc::new(seen_store));
 
     let client = axum_test::TestServer::new(app).unwrap();
 
@@ -1020,7 +1020,7 @@ async fn test_list_timeline() {
     let db_path = temp_dir.path().join("test.db");
     let config = Config::new(&upstream.url(), "0.0.0.0", 0, db_path);
     let seen_store = SeenUriStore::open(":memory:").unwrap();
-    let app = create_proxy_router(config, seen_store);
+    let app = create_proxy_router(config, std::sync::Arc::new(seen_store));
 
     let client = axum_test::TestServer::new(app).unwrap();
 
@@ -1042,7 +1042,7 @@ async fn test_instance_v2_for_streaming_discovery() {
     let db_path = temp_dir.path().join("test.db");
     let config = Config::new(&upstream.url(), "0.0.0.0", 0, db_path);
     let seen_store = SeenUriStore::open(":memory:").unwrap();
-    let app = create_proxy_router(config, seen_store);
+    let app = create_proxy_router(config, std::sync::Arc::new(seen_store));
 
     let client = axum_test::TestServer::new(app).unwrap();
 
@@ -1066,7 +1066,7 @@ async fn test_unauthorized_returns_401() {
     let db_path = temp_dir.path().join("test.db");
     let config = Config::new(&upstream.url(), "0.0.0.0", 0, db_path);
     let seen_store = SeenUriStore::open(":memory:").unwrap();
-    let app = create_proxy_router(config, seen_store);
+    let app = create_proxy_router(config, std::sync::Arc::new(seen_store));
 
     let client = axum_test::TestServer::new(app).unwrap();
 
@@ -1091,7 +1091,7 @@ async fn test_invalid_token_returns_401() {
     let db_path = temp_dir.path().join("test.db");
     let config = Config::new(&upstream.url(), "0.0.0.0", 0, db_path);
     let seen_store = SeenUriStore::open(":memory:").unwrap();
-    let app = create_proxy_router(config, seen_store);
+    let app = create_proxy_router(config, std::sync::Arc::new(seen_store));
 
     let client = axum_test::TestServer::new(app).unwrap();
 

--- a/tests/proxy_test.rs
+++ b/tests/proxy_test.rs
@@ -175,7 +175,7 @@ async fn test_proxy_forwards_get_request() {
     let db_path = temp_dir.path().join("test.db");
     let config = Config::new(&upstream.url(), "0.0.0.0", 0, db_path);
     let seen_store = SeenUriStore::open(":memory:").unwrap();
-    let app = create_proxy_router(config, seen_store);
+    let app = create_proxy_router(config, std::sync::Arc::new(seen_store));
 
     let client = axum_test::TestServer::new(app).unwrap();
     let response = client
@@ -196,7 +196,7 @@ async fn test_proxy_passes_auth_header() {
     let db_path = temp_dir.path().join("test.db");
     let config = Config::new(&upstream.url(), "0.0.0.0", 0, db_path);
     let seen_store = SeenUriStore::open(":memory:").unwrap();
-    let app = create_proxy_router(config, seen_store);
+    let app = create_proxy_router(config, std::sync::Arc::new(seen_store));
 
     let client = axum_test::TestServer::new(app).unwrap();
 
@@ -220,7 +220,7 @@ async fn test_proxy_forwards_post_request() {
     let db_path = temp_dir.path().join("test.db");
     let config = Config::new(&upstream.url(), "0.0.0.0", 0, db_path);
     let seen_store = SeenUriStore::open(":memory:").unwrap();
-    let app = create_proxy_router(config, seen_store);
+    let app = create_proxy_router(config, std::sync::Arc::new(seen_store));
 
     let client = axum_test::TestServer::new(app).unwrap();
     let response = client
@@ -243,7 +243,7 @@ async fn test_proxy_oauth_passthrough() {
     let db_path = temp_dir.path().join("test.db");
     let config = Config::new(&upstream.url(), "0.0.0.0", 0, db_path);
     let seen_store = SeenUriStore::open(":memory:").unwrap();
-    let app = create_proxy_router(config, seen_store);
+    let app = create_proxy_router(config, std::sync::Arc::new(seen_store));
 
     let client = axum_test::TestServer::new(app).unwrap();
     let response = client
@@ -268,7 +268,7 @@ async fn test_proxy_account_passthrough() {
     let db_path = temp_dir.path().join("test.db");
     let config = Config::new(&upstream.url(), "0.0.0.0", 0, db_path);
     let seen_store = SeenUriStore::open(":memory:").unwrap();
-    let app = create_proxy_router(config, seen_store);
+    let app = create_proxy_router(config, std::sync::Arc::new(seen_store));
 
     let client = axum_test::TestServer::new(app).unwrap();
     let response = client
@@ -289,7 +289,7 @@ async fn test_proxy_fallback_passthrough() {
     let db_path = temp_dir.path().join("test.db");
     let config = Config::new(&upstream.url(), "0.0.0.0", 0, db_path);
     let seen_store = SeenUriStore::open(":memory:").unwrap();
-    let app = create_proxy_router(config, seen_store);
+    let app = create_proxy_router(config, std::sync::Arc::new(seen_store));
 
     let client = axum_test::TestServer::new(app).unwrap();
     let response = client
@@ -423,7 +423,7 @@ async fn test_timeline_first_status_passes_through() {
     let db_path = temp_dir.path().join("test.db");
     let config = Config::new(&upstream.url(), "0.0.0.0", 0, db_path);
     let seen_store = SeenUriStore::open(":memory:").unwrap();
-    let app = create_proxy_router(config, seen_store);
+    let app = create_proxy_router(config, std::sync::Arc::new(seen_store));
 
     let client = axum_test::TestServer::new(app).unwrap();
     let response = client
@@ -453,7 +453,7 @@ async fn test_timeline_duplicates_are_filtered() {
     let db_path = temp_dir.path().join("test.db");
     let config = Config::new(&upstream.url(), "0.0.0.0", 0, db_path);
     let seen_store = SeenUriStore::open(":memory:").unwrap();
-    let app = create_proxy_router(config, seen_store);
+    let app = create_proxy_router(config, std::sync::Arc::new(seen_store));
 
     let client = axum_test::TestServer::new(app).unwrap();
 
@@ -504,7 +504,7 @@ async fn test_timeline_boost_deduplication() {
 
     let upstream = MockTimelineUpstream::start_with_statuses(boost_statuses).await;
     let config = Config::new(&upstream.url(), "0.0.0.0", 0, db_path);
-    let app = create_proxy_router(config, seen_store);
+    let app = create_proxy_router(config, std::sync::Arc::new(seen_store));
 
     let client = axum_test::TestServer::new(app).unwrap();
     let response = client
@@ -530,7 +530,7 @@ async fn test_timeline_public_filtering() {
     let db_path = temp_dir.path().join("test.db");
     let config = Config::new(&upstream.url(), "0.0.0.0", 0, db_path);
     let seen_store = SeenUriStore::open(":memory:").unwrap();
-    let app = create_proxy_router(config, seen_store);
+    let app = create_proxy_router(config, std::sync::Arc::new(seen_store));
 
     let client = axum_test::TestServer::new(app).unwrap();
 
@@ -559,7 +559,7 @@ async fn test_timeline_list_filtering() {
     let db_path = temp_dir.path().join("test.db");
     let config = Config::new(&upstream.url(), "0.0.0.0", 0, db_path);
     let seen_store = SeenUriStore::open(":memory:").unwrap();
-    let app = create_proxy_router(config, seen_store);
+    let app = create_proxy_router(config, std::sync::Arc::new(seen_store));
 
     let client = axum_test::TestServer::new(app).unwrap();
 
@@ -588,7 +588,7 @@ async fn test_timeline_hashtag_filtering() {
     let db_path = temp_dir.path().join("test.db");
     let config = Config::new(&upstream.url(), "0.0.0.0", 0, db_path);
     let seen_store = SeenUriStore::open(":memory:").unwrap();
-    let app = create_proxy_router(config, seen_store);
+    let app = create_proxy_router(config, std::sync::Arc::new(seen_store));
 
     let client = axum_test::TestServer::new(app).unwrap();
 
@@ -617,7 +617,7 @@ async fn test_timeline_status_without_uri_passes_through() {
     let db_path = temp_dir.path().join("test.db");
     let config = Config::new(&upstream.url(), "0.0.0.0", 0, db_path);
     let seen_store = SeenUriStore::open(":memory:").unwrap();
-    let app = create_proxy_router(config, seen_store);
+    let app = create_proxy_router(config, std::sync::Arc::new(seen_store));
 
     let client = axum_test::TestServer::new(app).unwrap();
 
@@ -653,7 +653,7 @@ async fn test_body_within_limit_succeeds() {
     // Use a small limit (1KB) for testing
     let config = Config::with_max_body_size(&upstream.url(), "0.0.0.0", 0, db_path, 1024);
     let seen_store = SeenUriStore::open(":memory:").unwrap();
-    let app = create_proxy_router(config, seen_store);
+    let app = create_proxy_router(config, std::sync::Arc::new(seen_store));
 
     let client = axum_test::TestServer::new(app).unwrap();
 
@@ -678,7 +678,7 @@ async fn test_body_exceeding_limit_returns_413() {
     // Use a small limit (1KB) for testing
     let config = Config::with_max_body_size(&upstream.url(), "0.0.0.0", 0, db_path, 1024);
     let seen_store = SeenUriStore::open(":memory:").unwrap();
-    let app = create_proxy_router(config, seen_store);
+    let app = create_proxy_router(config, std::sync::Arc::new(seen_store));
 
     let client = axum_test::TestServer::new(app).unwrap();
 
@@ -704,7 +704,7 @@ async fn test_default_body_limit_allows_normal_requests() {
     // Use default config (should have 50MB limit)
     let config = Config::new(&upstream.url(), "0.0.0.0", 0, db_path);
     let seen_store = SeenUriStore::open(":memory:").unwrap();
-    let app = create_proxy_router(config, seen_store);
+    let app = create_proxy_router(config, std::sync::Arc::new(seen_store));
 
     let client = axum_test::TestServer::new(app).unwrap();
 
@@ -736,7 +736,7 @@ async fn test_timeline_link_filtering() {
     let db_path = temp_dir.path().join("test.db");
     let config = Config::new(&upstream.url(), "0.0.0.0", 0, db_path);
     let seen_store = SeenUriStore::open(":memory:").unwrap();
-    let app = create_proxy_router(config, seen_store);
+    let app = create_proxy_router(config, std::sync::Arc::new(seen_store));
 
     let client = axum_test::TestServer::new(app).unwrap();
 
@@ -765,7 +765,7 @@ async fn test_trends_statuses_filtering() {
     let db_path = temp_dir.path().join("test.db");
     let config = Config::new(&upstream.url(), "0.0.0.0", 0, db_path);
     let seen_store = SeenUriStore::open(":memory:").unwrap();
-    let app = create_proxy_router(config, seen_store);
+    let app = create_proxy_router(config, std::sync::Arc::new(seen_store));
 
     let client = axum_test::TestServer::new(app).unwrap();
 
@@ -825,7 +825,7 @@ async fn test_accept_encoding_stripped_prevents_gzip() {
     let db_path = temp_dir.path().join("test.db");
     let config = Config::new(&format!("http://{}", addr), "0.0.0.0", 0, db_path);
     let seen_store = SeenUriStore::open(":memory:").unwrap();
-    let proxy_app = create_proxy_router(config, seen_store);
+    let proxy_app = create_proxy_router(config, std::sync::Arc::new(seen_store));
 
     let client = axum_test::TestServer::new(proxy_app).unwrap();
 
@@ -872,7 +872,7 @@ async fn test_same_content_different_authors_not_deduplicated() {
     let db_path = temp_dir.path().join("test.db");
     let config = Config::new(&upstream.url(), "0.0.0.0", 0, db_path);
     let seen_store = SeenUriStore::open(":memory:").unwrap();
-    let app = create_proxy_router(config, seen_store);
+    let app = create_proxy_router(config, std::sync::Arc::new(seen_store));
 
     let client = axum_test::TestServer::new(app).unwrap();
     let response = client
@@ -910,7 +910,7 @@ async fn test_reply_passes_through_with_seen_parent() {
 
     let upstream = MockTimelineUpstream::start_with_statuses(statuses).await;
     let config = Config::new(&upstream.url(), "0.0.0.0", 0, db_path);
-    let app = create_proxy_router(config, seen_store);
+    let app = create_proxy_router(config, std::sync::Arc::new(seen_store));
 
     let client = axum_test::TestServer::new(app).unwrap();
     let response = client
@@ -941,7 +941,7 @@ async fn test_thread_all_statuses_pass_through() {
     let db_path = temp_dir.path().join("test.db");
     let config = Config::new(&upstream.url(), "0.0.0.0", 0, db_path);
     let seen_store = SeenUriStore::open(":memory:").unwrap();
-    let app = create_proxy_router(config, seen_store);
+    let app = create_proxy_router(config, std::sync::Arc::new(seen_store));
 
     let client = axum_test::TestServer::new(app).unwrap();
     let response = client
@@ -975,7 +975,7 @@ async fn test_cross_instance_same_id_different_uri() {
     let db_path = temp_dir.path().join("test.db");
     let config = Config::new(&upstream.url(), "0.0.0.0", 0, db_path);
     let seen_store = SeenUriStore::open(":memory:").unwrap();
-    let app = create_proxy_router(config, seen_store);
+    let app = create_proxy_router(config, std::sync::Arc::new(seen_store));
 
     let client = axum_test::TestServer::new(app).unwrap();
     let response = client
@@ -1101,7 +1101,7 @@ async fn test_account_statuses_not_filtered() {
         .mark_seen("https://example.com/statuses/1")
         .unwrap();
 
-    let app = create_proxy_router(config, seen_store);
+    let app = create_proxy_router(config, std::sync::Arc::new(seen_store));
 
     let client = axum_test::TestServer::new(app).unwrap();
 
@@ -1148,7 +1148,7 @@ async fn test_thread_context_not_filtered() {
         .mark_seen("https://example.com/statuses/1")
         .unwrap();
 
-    let app = create_proxy_router(config, seen_store);
+    let app = create_proxy_router(config, std::sync::Arc::new(seen_store));
 
     let client = axum_test::TestServer::new(app).unwrap();
 
@@ -1186,7 +1186,7 @@ async fn test_bookmarks_not_filtered() {
         .mark_seen("https://example.com/statuses/1")
         .unwrap();
 
-    let app = create_proxy_router(config, seen_store);
+    let app = create_proxy_router(config, std::sync::Arc::new(seen_store));
 
     let client = axum_test::TestServer::new(app).unwrap();
 
@@ -1232,7 +1232,7 @@ async fn test_favourites_not_filtered() {
         .mark_seen("https://example.com/statuses/1")
         .unwrap();
 
-    let app = create_proxy_router(config, seen_store);
+    let app = create_proxy_router(config, std::sync::Arc::new(seen_store));
 
     let client = axum_test::TestServer::new(app).unwrap();
 
@@ -1261,7 +1261,7 @@ async fn test_health_endpoint_returns_ok() {
     let db_path = temp_dir.path().join("test.db");
     let config = Config::new(&upstream.url(), "0.0.0.0", 0, db_path);
     let seen_store = SeenUriStore::open(":memory:").unwrap();
-    let app = create_proxy_router(config, seen_store);
+    let app = create_proxy_router(config, std::sync::Arc::new(seen_store));
 
     let client = axum_test::TestServer::new(app).unwrap();
     let response = client.get("/health").await;
@@ -1280,7 +1280,7 @@ async fn test_health_endpoint_no_auth_required() {
     let db_path = temp_dir.path().join("test.db");
     let config = Config::new(&upstream.url(), "0.0.0.0", 0, db_path);
     let seen_store = SeenUriStore::open(":memory:").unwrap();
-    let app = create_proxy_router(config, seen_store);
+    let app = create_proxy_router(config, std::sync::Arc::new(seen_store));
 
     let client = axum_test::TestServer::new(app).unwrap();
     // No auth header
@@ -1297,7 +1297,7 @@ async fn test_health_endpoint_deep_check() {
     let db_path = temp_dir.path().join("test.db");
     let config = Config::new(&upstream.url(), "0.0.0.0", 0, db_path);
     let seen_store = SeenUriStore::open(":memory:").unwrap();
-    let app = create_proxy_router(config, seen_store);
+    let app = create_proxy_router(config, std::sync::Arc::new(seen_store));
 
     let client = axum_test::TestServer::new(app).unwrap();
     let response = client.get("/health?deep=true").await;

--- a/tests/replay_test.rs
+++ b/tests/replay_test.rs
@@ -193,7 +193,7 @@ async fn test_replay_timeline_deduplication() {
         db_path.clone(),
     );
     let seen_store = SeenUriStore::open(&db_path).unwrap();
-    let proxy_router = create_proxy_router(config, seen_store);
+    let proxy_router = create_proxy_router(config, std::sync::Arc::new(seen_store));
 
     // Create a test server
     let test_server = axum_test::TestServer::new(proxy_router).unwrap();
@@ -302,7 +302,7 @@ async fn test_real_traffic_deduplication() {
         db_path.clone(),
     );
     let seen_store = SeenUriStore::open(&db_path).unwrap();
-    let proxy_router = create_proxy_router(config, seen_store);
+    let proxy_router = create_proxy_router(config, std::sync::Arc::new(seen_store));
 
     let test_server = axum_test::TestServer::new(proxy_router).unwrap();
 

--- a/tests/websocket_test.rs
+++ b/tests/websocket_test.rs
@@ -155,7 +155,7 @@ async fn test_websocket_upgrade_succeeds() {
     let db_path = temp_dir.path().join("test.db");
     let config = Config::new(&upstream.url(), "0.0.0.0", 0, db_path);
     let seen_store = SeenUriStore::open(":memory:").unwrap();
-    let app = create_proxy_router(config, seen_store);
+    let app = create_proxy_router(config, std::sync::Arc::new(seen_store));
 
     // Start the proxy server
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -192,7 +192,7 @@ async fn test_bidirectional_message_relay() {
     let db_path = temp_dir.path().join("test.db");
     let config = Config::new(&upstream.url(), "0.0.0.0", 0, db_path);
     let seen_store = SeenUriStore::open(":memory:").unwrap();
-    let app = create_proxy_router(config, seen_store);
+    let app = create_proxy_router(config, std::sync::Arc::new(seen_store));
 
     // Start the proxy server
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -242,7 +242,7 @@ async fn test_upstream_to_client_relay() {
     let db_path = temp_dir.path().join("test.db");
     let config = Config::new(&upstream.url(), "0.0.0.0", 0, db_path);
     let seen_store = SeenUriStore::open(":memory:").unwrap();
-    let app = create_proxy_router(config, seen_store);
+    let app = create_proxy_router(config, std::sync::Arc::new(seen_store));
 
     // Start the proxy server
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -301,7 +301,7 @@ async fn test_websocket_deduplication() {
     let db_path = temp_dir.path().join("test.db");
     let config = Config::new(&upstream.url(), "0.0.0.0", 0, db_path);
     let seen_store = SeenUriStore::open(":memory:").unwrap();
-    let app = create_proxy_router(config, seen_store);
+    let app = create_proxy_router(config, std::sync::Arc::new(seen_store));
 
     // Start the proxy server
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -349,7 +349,7 @@ async fn test_websocket_close_handling() {
     let db_path = temp_dir.path().join("test.db");
     let config = Config::new(&upstream.url(), "0.0.0.0", 0, db_path);
     let seen_store = SeenUriStore::open(":memory:").unwrap();
-    let app = create_proxy_router(config, seen_store);
+    let app = create_proxy_router(config, std::sync::Arc::new(seen_store));
 
     // Start the proxy server
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -428,7 +428,7 @@ async fn test_websocket_different_statuses_not_deduplicated() {
     let db_path = temp_dir.path().join("test.db");
     let config = Config::new(&upstream.url(), "0.0.0.0", 0, db_path);
     let seen_store = SeenUriStore::open(":memory:").unwrap();
-    let app = create_proxy_router(config, seen_store);
+    let app = create_proxy_router(config, std::sync::Arc::new(seen_store));
 
     // Start the proxy server
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();


### PR DESCRIPTION
## Summary

Adds a background task that periodically cleans up old entries from the SeenUriStore database to prevent unbounded growth.

## Changes

- Add `cleanup_interval_secs` (default: 3600 = 1 hour) and `cleanup_max_age_secs` (default: 604800 = 7 days) configuration options to CLI, env vars, and config files
- Create `src/cleanup.rs` module with `spawn_cleanup_task()` function that runs periodically
- Update `create_proxy_router()` to accept `Arc<SeenUriStore>` for sharing between the HTTP server and cleanup task
- Add comprehensive tests for cleanup functionality

## Configuration

The cleanup task can be configured via:
- CLI: `--cleanup-interval-secs` and `--cleanup-max-age-secs`
- Env vars: `IV_CLEANUP_INTERVAL_SECS` and `IV_CLEANUP_MAX_AGE_SECS`
- Config file: `cleanup_interval_secs` and `cleanup_max_age_secs`

## Test plan

- [x] Unit tests for cleanup logic pass
- [x] Unit tests for config options pass
- [x] All existing integration tests pass
- [x] `cargo clippy` passes without warnings
- [x] `cargo fmt --check` passes

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)