### PR TITLE
feat: Accept gzip-compressed responses and decompress on proxy side

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -476,6 +482,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "criterion"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -659,6 +674,16 @@ name = "find-msvc-tools"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
+
+[[package]]
+name = "flate2"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "form_urlencoded"
@@ -1116,6 +1141,7 @@ dependencies = [
  "clap",
  "config",
  "criterion",
+ "flate2",
  "futures-util",
  "pretty_assertions",
  "reqwest",
@@ -1241,6 +1267,16 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
 
 [[package]]
 name = "mio"
@@ -1540,7 +1576,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2002,6 +2038,12 @@ checksum = "7664a098b8e616bdfcc2dc0e9ac44eb231eedf41db4e9fe95d8d32ec728dedad"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
 name = "slab"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,9 @@ serde_json = "1"
 # Database
 rusqlite = { version = "0.32", features = ["bundled"] }
 
+# Compression for handling gzip/deflate responses
+flate2 = "1.0"
+
 # Logging
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
@@ -62,6 +65,9 @@ pretty_assertions = "1"
 
 # Benchmarking
 criterion = { version = "0.5", features = ["html_reports", "async_tokio"] }
+
+# Compression for test fixtures (already in dependencies, listed for clarity)
+flate2 = "1.0"
 
 [[bench]]
 name = "performance"


### PR DESCRIPTION
## Summary

This PR implements gzip/deflate decompression for HTTP responses from upstream Mastodon servers. The proxy now:
- Sends `Accept-Encoding: gzip, deflate` to upstream servers
- Decompresses gzip and deflate responses before processing
- Continues to parse JSON correctly for deduplication
- Returns uncompressed responses to clients

**Benefits:**
- Reduces bandwidth usage between proxy and upstream servers
- Makes the proxy a better network citizen (servers expect clients to accept compression)
- Improves performance with less data to transfer

## Changes

- Add `flate2` crate for gzip/deflate decompression
- Remove `accept-encoding` from `STRIP_HEADERS` and explicitly add `Accept-Encoding: gzip, deflate` to outgoing requests
- Add `decompress_response_body()` function to handle compression
- Add `ProxyError::Decompression` variant for decompression errors (returns 502 Bad Gateway)
- Strip `Content-Encoding` from forwarded responses (we decompress before forwarding)
- Add 6 new unit tests for `decompress_response_body()`
- Add 6 new integration tests for compression handling

## Testing

- All 155 tests pass
- Clippy passes with no warnings
- Code is properly formatted
- Followed TDD: tests written before implementation

### Test Coverage

**Unit tests:**
- `test_decompress_gzip_body` - Verify gzip decompression
- `test_decompress_deflate_body` - Verify deflate decompression  
- `test_decompress_no_encoding` - Verify passthrough when no encoding
- `test_decompress_unknown_encoding_passes_through` - Verify unknown encodings pass through
- `test_decompress_invalid_gzip_returns_error` - Verify error handling
- `test_decompress_empty_body` - Verify empty body handling

**Integration tests:**
- `test_gzip_response_decompressed_and_filtered` - Full gzip flow with deduplication
- `test_deflate_response_decompressed` - Full deflate flow
- `test_malformed_gzip_returns_error` - Verify 502 on malformed data
- `test_accept_encoding_sent_to_upstream` - Verify header is sent
- `test_uncompressed_response_still_works` - Regression test
- `test_content_encoding_not_forwarded` - Verify header is stripped

Closes #67